### PR TITLE
Make moptilities work with ASDF 3.3

### DIFF
--- a/dev/moptilities.lisp
+++ b/dev/moptilities.lisp
@@ -1,13 +1,6 @@
 ;;;; -*- Mode: Common-Lisp; Package: metabang.moptilities; Base: 10 -*-
 ;;;; some definitions are from the Art of the MOP
 
-(in-package #:cl-user)
-
-#+sbcl
-(eval-when (:compile-toplevel :load-toplevel)
-  (require 'sb-introspect)              ; for function-arglist
-)
-
 (defpackage #:metabang.moptilities
   (:documentation "Moptilities builds on the Lisp Meta-Object Protocol (**MOP**).")
   (:use #:closer-common-lisp)

--- a/moptilities-test.asd
+++ b/moptilities-test.asd
@@ -6,23 +6,18 @@ See the file COPYING for details
 
 |#
 
-(defpackage #:asdf-moptilities-test (:use #:asdf #:cl))
-(in-package #:asdf-moptilities-test)
-
-(defsystem moptilities-test
+(defsystem "moptilities-test"
   :version "0.1"
   :author "Gary Warren King <gwking@metabang.com>"
   :maintainer "Gary Warren King <gwking@metabang.com>"
   :licence "MIT Style license"
   :description "Test for Common Lisp MOP utilities"
-  :components ((:module 
-		"tests"
-		:components ((:file "package")
-			     (:file "tests" :depends-on ("package"))
-			     (:file "copy-template" :depends-on ("tests"))))
-               
+  :components ((:module
+                "tests"
+                :components ((:file "package")
+                             (:file "tests" :depends-on ("package"))
+                             (:file "copy-template" :depends-on ("tests"))))
                (:module "dev"
                         :components ((:static-file "notes.text"))))
-  :depends-on (:moptilities :lift))
-
-
+  :depends-on ("moptilities" "lift")
+  :perform (test-op (o c) (symbol-call :lift :run-tests :config :generic)))

--- a/moptilities.asd
+++ b/moptilities.asd
@@ -6,34 +6,23 @@ See the file COPYING for details
 
 |#
 
-(defpackage #:asdf-moptilities (:use #:asdf #:cl))
-(in-package #:asdf-moptilities)
-
-(defsystem moptilities
+(defsystem "moptilities"
   :author "Gary Warren King <gwking@metabang.com>"
   :version "0.3.13"
   :maintainer "Gary Warren King <gwking@metabang.com>"
   :licence "MIT Style license"
   :description "Common Lisp MOP utilities"
   :long-description "MOP utilities provide a common interface between lisps and make the MOP easier to use."
-
   :components
   ((:module
     "dev"
     :components ((:file "moptilities")
-		 (:static-file "notes.text")))
+                 (:static-file "notes.text")))
    (:module
     "website"
     :components
     ((:module "source"
-	      :components ((:static-file "index.md"))))))
-  :in-order-to ((test-op (load-op moptilities-test)))
-  :perform (test-op :after (op c)
-		    (funcall
-		      (intern (symbol-name '#:run-tests) :lift)
-		      :config :generic))
-  :depends-on (:closer-mop))
-
-(defmethod operation-done-p
-           ((o test-op) (c (eql (find-system 'moptilities))))
-  (values nil))
+              :components ((:static-file "index.md"))))))
+  :in-order-to ((test-op (test-op "moptilities-test")))
+  :depends-on ("closer-mop"
+               (:feature :sbcl (:require :sb-introspect)))) ; for function-arglist


### PR DESCRIPTION
Also refactor to follow current best practices for ASDF.
Compatibility back to ASDF 2.32 (2013) only.